### PR TITLE
Only run CI on master and pull requests to master

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -5,7 +5,7 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ '*' ]
+    branches: [ master ]
   pull_request:
     branches: [ master ]
 


### PR DESCRIPTION
#### Overview of changes

- CI was set to run on pushes to every branch. This has been changed so it will only run on pushes to master and pull requests to master.

Reviewer: @johnanvik
