### PR TITLE
Added CardWithOverlays component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ coverage/
 documents/
 
 *.swp
+*.orig

--- a/src/components/MainGame/PlayerInfoPanel.vue
+++ b/src/components/MainGame/PlayerInfoPanel.vue
@@ -43,11 +43,11 @@
             <h5 style="vertical-align: center; margin-left: auto; margin-right: auto" :style="pIPTextColour()">Score Limit: <b>{{getScoreLimit()}}</b></h5>
             <h4 class="modal-title" :style="pIPTextColour()"><b>{{ currentPlayerName() }}</b>, It's Your Turn</h4>
               <li v-for="(card) in hand" v-bind:key="card.id" style="margin-top: 5px; position: relative;">
-                <card-with-overlay :card="card"
+                <card-with-overlays :card="card"
                     v-on:cardClicked="cardClicked"
                     v-on:setActiveCard="setActiveCard"
                     v-on:discard-card="discardSelected">
-                </card-with-overlay>
+                </card-with-overlays>
               </li>
           </ul>
         </div>
@@ -124,7 +124,7 @@ export default {
 
     },
     components: {
-      'card-with-overlay': CardWithOverlays,
+      'card-with-overlays': CardWithOverlays,
       'display-used-cards': DisplayUsedCards,
       'modal': Modal
     },

--- a/src/components/MainGame/PlayerInfoPanel.vue
+++ b/src/components/MainGame/PlayerInfoPanel.vue
@@ -43,12 +43,11 @@
             <h5 style="vertical-align: center; margin-left: auto; margin-right: auto" :style="pIPTextColour()">Score Limit: <b>{{getScoreLimit()}}</b></h5>
             <h4 class="modal-title" :style="pIPTextColour()"><b>{{ currentPlayerName() }}</b>, It's Your Turn</h4>
               <li v-for="(card) in hand" v-bind:key="card.id" style="margin-top: 5px; position: relative;">
-                  <input type="image" title="Discard Card"
-                     src="static/miscIcons/trash.png"
-                     v-if="isActiveCard(card)"
-                     v-on:click="discardSelected"
-                     style="width: 25px; height: 25px; left: -8px; top: -8px; position: absolute">
-                  <card :cardData="card" v-on:cardClicked="cardClicked" @setActiveCard="setActiveCard"></card>
+                <card-with-overlay :card="card"
+                    v-on:cardClicked="cardClicked"
+                    v-on:setActiveCard="setActiveCard"
+                    v-on:discard-card="discardSelected">
+                </card-with-overlay>
               </li>
           </ul>
         </div>
@@ -72,7 +71,7 @@
   /* eslint-disable no-undef */
 
 import { bus } from '../SharedComponents/Bus'
-import Card from '../SharedComponents/Card'
+import CardWithOverlays from '../SharedComponents/CardWithOverlays'
 import Modal from '../Modals/Modal'
 import DisplayUsedCards from '../SharedComponents/DisplayUsedCards'
 
@@ -125,7 +124,7 @@ export default {
 
     },
     components: {
-      'card': Card,
+      'card-with-overlay': CardWithOverlays,
       'display-used-cards': DisplayUsedCards,
       'modal': Modal
     },

--- a/src/components/SharedComponents/CardWithOverlays.vue
+++ b/src/components/SharedComponents/CardWithOverlays.vue
@@ -1,0 +1,67 @@
+<template>
+  <div class="card-overlay">
+    <div id="overlay" v-if="isSelected">
+
+      <input type="image" id="discard-button"
+         title="Discard Card"
+         src="static/miscIcons/trash.png"
+         v-on:click="discardCard">
+    </div>
+
+    <card v-bind:cardData="card"
+       v-on:cardClicked="cardClicked"
+       v-on:setActiveCard="setActiveCard">
+    </card>
+  </div> 
+</template>
+
+
+<script>
+/* eslint-disable */
+import Card from './Card'
+import {mapGetters} from 'vuex'
+
+
+export default {
+  name: 'CardWithOverlay',
+  props: ['card'],
+  data () {
+    return {
+      type: this.card.type
+    }
+  },
+  components: {
+    'card': Card,
+  },
+  computed: {
+    isSelected () {
+      return this.card === this.getActiveCard()
+    }
+  },
+  methods: {
+    ...mapGetters([
+      'getActiveCard'
+    ]),
+    cardClicked (c) {
+      this.$emit('cardClicked', c)
+    },
+    setActiveCard (c) {
+      this.$emit('setActiveCard', c)
+    },
+    discardCard () {
+      this.$emit('discard-card')
+    }
+  }
+}
+</script>
+
+
+<style scoped>
+#discard-button {
+  position: absolute;
+  left: -8px;
+  top: -8px;
+  width: 25px;
+  height: 25px; 
+}
+</style>


### PR DESCRIPTION
Fixes #528 - partially

#### Overview of changes

- Created a CardWithOverlays component to hold a card and any buttons or popups associated with that card when it is selected. This is to support moving playing attack/safety cards from modals to popups overlayed on top of the card being played.
- Replaced card component in PlayerInfoPanel with this new component.

Reviewer: @johnanvik
