### PR TITLE
Card overlay part2 #528

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ coverage/
 documents/
 
 *.swp
+*.orig

--- a/src/classes/Models/Player.js
+++ b/src/classes/Models/Player.js
@@ -59,4 +59,14 @@ export default class Player {
   updateBonus (score) {
     this.bonus += score
   }
+
+  /**
+   * Checks to see if the player is under the effect of a given safety
+   * or remedy card.
+   * @param {string} cardType the type of card to check for.
+   * @return true if the player is protected by the card type, otherwise false
+   */
+  protectedBy (cardType) {
+    return this.usedBonusCards.find(c => c.type === cardType) !== undefined)
+  }
 }

--- a/src/classes/Models/Player.js
+++ b/src/classes/Models/Player.js
@@ -67,6 +67,6 @@ export default class Player {
    * @return true if the player is protected by the card type, otherwise false
    */
   protectedBy (cardType) {
-    return this.usedBonusCards.find(c => c.type === cardType) !== undefined)
+    return this.usedBonusCards.find(c => c.type === cardType) !== undefined
   }
 }

--- a/src/classes/Models/Player.js
+++ b/src/classes/Models/Player.js
@@ -67,6 +67,9 @@ export default class Player {
    * @return true if the player is protected by the card type, otherwise false
    */
   protectedBy (cardType) {
+    if (cardType === "BATTERYBACKUP" && this.hasGenerator) {
+      return true
+    }
     return this.usedBonusCards.find(c => c.type === cardType) !== undefined
   }
 }

--- a/src/components/MainGame/MainComponent.vue
+++ b/src/components/MainGame/MainComponent.vue
@@ -10,16 +10,6 @@
                  data-backdrop="static" data-keyboard="false"></virus-modal>
     <power-outage-modal id="powerOutageModal" class="modal fade powerOutage" tabindex="-1" role="dialog" aria-labelledby="" aria-hidden="true" :players="players"
                  data-backdrop="static" data-keyboard="false"></power-outage-modal>
-    <battery-backup-modal id="batteryBackupModal" class="modal fade batteryBackup" tabindex="-1" role="dialog" aria-labelledby="" aria-hidden="true" :players="players"
-                        data-backdrop="static" data-keyboard="false"></battery-backup-modal>
-    <overclock-modal id="overclockModal" class="modal fade overclock" tabindex="-1" role="dialog" aria-labelledby="" aria-hidden="true" :players="players"
-                          data-backdrop="static" data-keyboard="false"></overclock-modal>
-    <firewall-modal id="firewallModal" class="modal fade firewall" tabindex="-1" role="dialog" aria-labelledby="" aria-hidden="true" :players="players"
-                     data-backdrop="static" data-keyboard="false"></firewall-modal>
-    <generator-modal id="generatorModal" class="modal fade generator" tabindex="-1" role="dialog" aria-labelledby="" aria-hidden="true" :players="players"
-                     data-backdrop="static" data-keyboard="false"></generator-modal>
-    <anti-virus-modal id="antiVirusModal" class="modal fade antiVirus" tabindex="-1" role="dialog" aria-labelledby="" aria-hidden="true" :players="players"
-                     data-backdrop="static" data-keyboard="false"></anti-virus-modal>
 
     <winner-modal id="winnerModal" class="modal fade winner" tabindex="-1" role="dialog" aria-labelledby="" aria-hidden="true" data-backdrop="static" data-keyboard="false"
     :playerList="playerList"></winner-modal>
@@ -82,11 +72,6 @@ import WinnerModal from '../Modals/WinnerModal.vue'
 import HackDiscard from '../Modals/CardModals/HackDiscardMsg.vue'
 import VirusModal from '../Modals/CardModals/VirusModal.vue'
 import PowerOutageModal from '../Modals/CardModals/PowerOutageModal'
-import BatteryBackup from '../Modals/CardModals/BatteryBackup'
-import Overclock from '../Modals/CardModals/OverclockModal'
-import AntiVirus from '../Modals/CardModals/AntiVirusModal'
-import Generator from '../Modals/CardModals/Generator'
-import Firewall from '../Modals/CardModals/Firewall'
 import Timer from '../SharedComponents/Timer'
 
 import Themes from '../Modals/ThemesModal'
@@ -131,11 +116,6 @@ export default {
       'hack-discard': HackDiscard,
       'virus-modal': VirusModal,
       'power-outage-modal': PowerOutageModal,
-      'battery-backup-modal': BatteryBackup,
-      'overclock-modal': Overclock,
-      'firewall-modal': Firewall,
-      'generator-modal': Generator,
-      'anti-virus-modal': AntiVirus,
       'timer': Timer,
       'themes-modal': Themes
 

--- a/src/components/MainGame/PlayerInfoPanel.vue
+++ b/src/components/MainGame/PlayerInfoPanel.vue
@@ -46,7 +46,8 @@
                 <card-with-overlays :card="card"
                     v-on:cardClicked="cardClicked"
                     v-on:setActiveCard="setActiveCard"
-                    v-on:discard-card="discardSelected">
+                    v-on:discard-card="discardSelected"
+                    v-on:played-card="cardPlayed">
                 </card-with-overlays>
               </li>
           </ul>
@@ -223,7 +224,9 @@ export default {
           $('.virus').modal('show')
         } else if (c.type === 'POWEROUTAGE') {
           $('.powerOutage').modal('show')
-        } else if (c.type === 'BATTERYBACKUP') {
+        }
+        /* Replace these with popups to play safety cards
+         else if (c.type === 'BATTERYBACKUP') {
           $('.batteryBackup').modal('show')
         } else if (c.type === 'OVERCLOCK') {
           $('.overclock').modal('show')
@@ -234,6 +237,7 @@ export default {
         } else if (c.type === 'ANTIVIRUS') {
           $('.antiVirus').modal('show')
         }
+        */
 
         this.selectCard(c)
         if (prevActive !== undefined) {
@@ -242,6 +246,10 @@ export default {
             this.setStackSelectedBoolean({payload: undefined})
           }
         }
+      },
+      cardPlayed (card, targetPlayer) {
+        console.log(card);
+        console.log(targetPlayer);
       },
       /**
        * This changes gathers which instruction to display in the text box

--- a/src/components/MainGame/PlayerInfoPanel.vue
+++ b/src/components/MainGame/PlayerInfoPanel.vue
@@ -43,11 +43,11 @@
             <h5 style="vertical-align: center; margin-left: auto; margin-right: auto" :style="pIPTextColour()">Score Limit: <b>{{getScoreLimit()}}</b></h5>
             <h4 class="modal-title" :style="pIPTextColour()"><b>{{ currentPlayerName() }}</b>, It's Your Turn</h4>
               <li v-for="(card) in hand" v-bind:key="card.id" style="margin-top: 5px; position: relative;">
-                <card-with-overlay :card="card"
+                <card-with-overlays :card="card"
                     v-on:cardClicked="cardClicked"
                     v-on:setActiveCard="setActiveCard"
                     v-on:discard-card="discardSelected">
-                </card-with-overlay>
+                </card-with-overlays>
               </li>
           </ul>
         </div>
@@ -124,7 +124,7 @@ export default {
 
     },
     components: {
-      'card-with-overlay': CardWithOverlays,
+      'card-with-overlays': CardWithOverlays,
       'display-used-cards': DisplayUsedCards,
       'modal': Modal
     },

--- a/src/components/MainGame/PlayerInfoPanel.vue
+++ b/src/components/MainGame/PlayerInfoPanel.vue
@@ -43,12 +43,11 @@
             <h5 style="vertical-align: center; margin-left: auto; margin-right: auto" :style="pIPTextColour()">Score Limit: <b>{{getScoreLimit()}}</b></h5>
             <h4 class="modal-title" :style="pIPTextColour()"><b>{{ currentPlayerName() }}</b>, It's Your Turn</h4>
               <li v-for="(card) in hand" v-bind:key="card.id" style="margin-top: 5px; position: relative;">
-                  <input type="image" title="Discard Card"
-                     src="static/miscIcons/trash.png"
-                     v-if="isActiveCard(card)"
-                     v-on:click="discardSelected"
-                     style="width: 25px; height: 25px; left: -8px; top: -8px; position: absolute">
-                  <card :cardData="card" v-on:cardClicked="cardClicked" @setActiveCard="setActiveCard"></card>
+                <card-with-overlay :card="card"
+                    v-on:cardClicked="cardClicked"
+                    v-on:setActiveCard="setActiveCard"
+                    v-on:discard-card="discardSelected">
+                </card-with-overlay>
               </li>
           </ul>
         </div>
@@ -72,7 +71,7 @@
   /* eslint-disable no-undef */
 
 import { bus } from '../SharedComponents/Bus'
-import Card from '../SharedComponents/Card'
+import CardWithOverlays from '../SharedComponents/CardWithOverlays'
 import Modal from '../Modals/Modal'
 import DisplayUsedCards from '../SharedComponents/DisplayUsedCards'
 
@@ -125,7 +124,7 @@ export default {
 
     },
     components: {
-      'card': Card,
+      'card-with-overlay': CardWithOverlays,
       'display-used-cards': DisplayUsedCards,
       'modal': Modal
     },

--- a/src/components/MainGame/PlayerInfoPanel.vue
+++ b/src/components/MainGame/PlayerInfoPanel.vue
@@ -225,19 +225,6 @@ export default {
         } else if (c.type === 'POWEROUTAGE') {
           $('.powerOutage').modal('show')
         }
-        /* Replace these with popups to play safety cards
-         else if (c.type === 'BATTERYBACKUP') {
-          $('.batteryBackup').modal('show')
-        } else if (c.type === 'OVERCLOCK') {
-          $('.overclock').modal('show')
-        } else if (c.type === 'FIREWALL') {
-          $('.firewall').modal('show')
-        } else if (c.type === 'GENERATOR') {
-          $('.generator').modal('show')
-        } else if (c.type === 'ANTIVIRUS') {
-          $('.antiVirus').modal('show')
-        }
-        */
 
         this.selectCard(c)
         if (prevActive !== undefined) {
@@ -247,9 +234,44 @@ export default {
           }
         }
       },
+      /**
+       * Apply the given bonus card the given player.
+       */
+      applyCard (card, player) {
+        let type = card.type
+        let id = player.id
+
+        if (type === 'BATTERYBACKUP') {
+          this.giveBatteryBackup(id)
+        } else if (type === 'OVERCLOCK') {
+          this.giveOverclock(id)
+        } else if (type === 'FIREWALL') {
+          this.giveFirewall(id)
+        } else if (type === 'ANTIVIRUS') {
+          this.giveAntiVirus(id)
+        } else if (type === 'GENERATOR') {
+          this.giveGenerator(id)
+        } else if (type === 'VIRUS') {
+          this.giveVirus(id)
+        } else if (type === 'POWEROUTAGE') {
+          this.givePowerOutage(id)
+        }
+      },
+      /**
+       * Plays the given bonus card on the target player and ends the current
+       * players turn.
+       */
       cardPlayed (card, targetPlayer) {
-        console.log(card);
-        console.log(targetPlayer);
+        this.applyCard(card, targetPlayer)
+
+        if (this.getTutorialState()) {
+          bus.$emit('cardPlayed')
+          this.increaseFactIndex()
+        }
+
+        this.playerTookTurn()
+        this.turn(true)
+        bus.$emit('alterTipBox')
       },
       /**
        * This changes gathers which instruction to display in the text box

--- a/src/components/SharedComponents/CardWithOverlays.vue
+++ b/src/components/SharedComponents/CardWithOverlays.vue
@@ -36,6 +36,17 @@ export default {
   computed: {
     isSelected () {
       return this.card === this.getActiveCard()
+    },
+    isAttack () {
+      return this.type === 'H' || this.type === 'VIRUS' || this.type === 'POWEROUTAGE'
+    },
+    isSafety () {
+      return (this.type === 'OVERCLOCK' || this.type === 'BATTERYBACKUP'
+          || this.type === 'GENERATOR' || this.type === 'ANTIVIRUS'
+          || this.type === 'FIREWALL')
+    },
+    canPlaySafety () {
+      return !this.getCurrentPlayer().protectedBy(this.type)
     }
   },
   methods: {

--- a/src/components/SharedComponents/CardWithOverlays.vue
+++ b/src/components/SharedComponents/CardWithOverlays.vue
@@ -6,6 +6,21 @@
          title="Discard Card"
          src="static/miscIcons/trash.png"
          v-on:click="discardCard">
+
+      <div id="play" class="popup" v-if="isSafety">
+        <div v-if="canPlaySafety">
+          <h5>Activate</h5>
+          <div id="button-wrapper"> 
+            <button id="safety-button" v-on:click="playSafety">
+              OK
+            </button>
+          </div>
+        </div>
+        <div v-else>
+          <h5>In Use</h5>
+        </div>
+      </div>
+
     </div>
 
     <card v-bind:cardData="card"
@@ -51,7 +66,8 @@ export default {
   },
   methods: {
     ...mapGetters([
-      'getActiveCard'
+      'getActiveCard',
+      'getCurrentPlayer'
     ]),
     cardClicked (c) {
       this.$emit('cardClicked', c)
@@ -61,6 +77,9 @@ export default {
     },
     discardCard () {
       this.$emit('discard-card')
+    },
+    playSafety () {
+      this.$emit('played-card')
     }
   }
 }
@@ -74,5 +93,32 @@ export default {
   top: -8px;
   width: 25px;
   height: 25px; 
+}
+
+.popup {
+  position: absolute;
+  left: -12px;
+  top: 30px;
+  background-color: white;
+  border: solid black 2px;
+  width: 114px;
+  height: auto;
+}
+
+#button-wrapper {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin-left: 3px;
+  margin-right: 3px;
+  margin-bottom: 3px;
+}
+
+#target-button {
+  display: block;
+}
+
+#play-button {
+  display: block;
 }
 </style>

--- a/src/components/SharedComponents/CardWithOverlays.vue
+++ b/src/components/SharedComponents/CardWithOverlays.vue
@@ -78,8 +78,11 @@ export default {
     discardCard () {
       this.$emit('discard-card')
     },
+    playCard (targetPlayer) {
+      this.$emit('played-card', this.card, targetPlayer)
+    },
     playSafety () {
-      this.$emit('played-card')
+      this.playCard(this.getCurrentPlayer())
     }
   }
 }

--- a/src/components/SharedComponents/CardWithOverlays.vue
+++ b/src/components/SharedComponents/CardWithOverlays.vue
@@ -1,0 +1,67 @@
+<template>
+  <div class="card-overlay">
+    <div id="overlay" v-if="isSelected">
+
+      <input type="image" id="discard-button"
+         title="Discard Card"
+         src="static/miscIcons/trash.png"
+         v-on:click="discardCard">
+    </div>
+
+    <card v-bind:cardData="card"
+       v-on:cardClicked="cardClicked"
+       v-on:setActiveCard="setActiveCard">
+    </card>
+  </div> 
+</template>
+
+
+<script>
+/* eslint-disable */
+import Card from './Card'
+import {mapGetters} from 'vuex'
+
+
+export default {
+  name: 'CardWithOverlay',
+  props: ['card'],
+  data () {
+    return {
+      type: this.card.type
+    }
+  },
+  components: {
+    'card': Card,
+  },
+  computed: {
+    isSelected () {
+      return this.card === this.getActiveCard()
+    }
+  },
+  methods: {
+    ...mapGetters([
+      'getActiveCard'
+    ]),
+    cardClicked (c) {
+      this.$emit('cardClicked', c)
+    },
+    setActiveCard (c) {
+      this.$emit('setActiveCard', c)
+    },
+    discardCard () {
+      this.$emit('discard-card')
+    }
+  }
+}
+</script>
+
+
+<style scoped>
+#discard-button {
+  position: absolute;
+  left: -8px;
+  top: -8px;
+  width: 25px;
+  height: 25px; 
+}
+</style>


### PR DESCRIPTION
Fixes #528 - partially

#### Overview of changes

- Added popups for safety/remedy cards to the CardWithOverlays component. Now clicking these cards brings up a small popup on the card that will allow the player to activate the card if desired. If the player has the card already played or an equivalent the popup will display **in use**.
- Added a method to the player class to check to see if a player is protectedBy a specific card type.
- Added functions for playing bonus cards in the PlayerInfoPanel component. These will likely work for the attack (except hack) cards as well when they are implemented with popups.
- Removed reference to the safety/remedy modals in the MainComponent.

Reviewer: @johnanvik
